### PR TITLE
fix: delete scanner on destroy

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -124,6 +124,9 @@ unsigned tree_sitter_arduino_external_scanner_serialize(void *payload, char *buf
 
 void tree_sitter_arduino_external_scanner_deserialize(void *payload, const char *buffer, unsigned length) {}
 
-void tree_sitter_arduino_external_scanner_destroy(void *payload) {}
+void tree_sitter_arduino_external_scanner_destroy(void *payload) {
+  Scanner *scanner = static_cast<Scanner *>(payload);
+  delete scanner;
+}
 
 }


### PR DESCRIPTION
fuzzing detected this memory leak

```
==940083==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 96 byte(s) in 3 object(s) allocated from:
    #0 0x55c0e4c75f09 in malloc (/home/amaanq/projects/treesitter/tree-sitter-arduino/fuzzer/fuzzer+0x163f09) (BuildId: 44bbbe897508391c059465bb1c645b0ca4f953a4)
    #1 0x7fc0782b089c in operator new(unsigned long) /usr/src/debug/gcc/gcc/libstdc++-v3/libsupc++/new_op.cc:50:22
    #2 0x7fc07861e16e in ts_parser_set_language (/usr/lib/libtree-sitter.so.0+0xf16e) (BuildId: 6f679524788ff1102c31b3aa192a2ad60bf255eb)
    
```